### PR TITLE
Increase fiddliness by genericizing serve_note_server.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ pwd
 
 Then, open the file `com.robinsloan.note_server.plist` with a text editor and replace the string `PATH_TO_NOTE_SERVER_DIRECTORY_HERE` with the absolute path you just printed out.
 
+And now—that cool thing you just did? Do it once more in `serve_note_server.sh`, making sure to keep the `cd` and only replace `PATH_TO_NOTE_SERVER_DIRECTORY_HERE`.
+
 **This has been the fiddly but important step.**
 
 Having fiddled with that successfully, you can register the ✨LaunchAgent✨ that will automatically start this server when you log into your computer:

--- a/serve_note_server.sh
+++ b/serve_note_server.sh
@@ -1,4 +1,4 @@
 #!bin/bash
 
-cd /Users/robin/Dropbox/dev-share/note-server
-/Users/robin/.rbenv/shims/rackup -p 9988 -E development -D
+cd PATH_TO_NOTE_SERVER_DIRECTORY_HERE
+rackup -p 9988 -E development -D


### PR DESCRIPTION
Hi Robin!

This almost immediately worked for me—it's great. All I had to change was `serve_note_server.sh`, which still had your local working directory in there. I swapped it out for another `PATH_TO_NOTE_SERVER_DIRECTORY_HERE` and noted it in the README.

I also removed the reference to your rbenv shims. I _think_ just calling `rackup` will work, assuming `gem` is installing into the PATH.

Thanks for building this, and thanks for Penumbra & P's New Fiction.